### PR TITLE
Adding CameraEncode example

### DIFF
--- a/examples/js/CameraEncode.js
+++ b/examples/js/CameraEncode.js
@@ -13,10 +13,11 @@ omx.Component.initAll([Clock, Camera, ImageEncode])
 
         var ws = require('stream').Writable();
         ws._write = function (chunk, enc, next) {
-            console.log("Received compressed frame with length: ", chunk.length);
             next();
 
             if (chunk.onBufferDone) {
+                console.log("Received compressed frame with length: ",
+                    chunk.length, " but used: ", chunk.usedLength);
                 chunk.onBufferDone();
             }
         };

--- a/examples/js/CameraEncode.js
+++ b/examples/js/CameraEncode.js
@@ -1,0 +1,38 @@
+"use strict";
+var stream = require('stream');
+var omx = require('openmax');
+
+var Clock = new omx.Clock();
+var Camera = new omx.Camera();
+var ImageEncode = new omx.ImageEncode();
+
+
+omx.Component.initAll([Clock, Camera, ImageEncode])
+    .then(function () {
+        Camera.setFormat().enable();
+
+        var ws = require('stream').Writable();
+        ws._write = function (chunk, enc, next) {
+            console.log("Received compressed frame with length: ", chunk.length);
+            next();
+
+            if (chunk.onBufferDone) {
+                chunk.onBufferDone();
+            }
+        };
+
+        ImageEncode.setInputFormat(omx.IMAGE_CODINGTYPE.IMAGE_CodingJPEG);
+
+        Clock.run();
+        Clock
+            .tunnel(Camera)
+            .pipe(ImageEncode)
+            .pipe(ws)
+            .on('finish', function () {
+                console.log("Done");
+            });
+    });
+setTimeout(function () {
+    Clock.stop();
+}, 5000);
+

--- a/lib/Component.ts
+++ b/lib/Component.ts
@@ -299,7 +299,7 @@ export class Component extends stream.Duplex {
     return this.component.setParameter(port, index, format);
   }
   sendCommand(commandType: omx.COMMANDTYPE, port: number) {
-    this.debug('sendCommand',commandType, port);
+    this.debug('sendCommand', commandType, port);
     return this.component.sendCommand(commandType, port);
   }
   disableAllPorts() {
@@ -448,13 +448,13 @@ export class Component extends stream.Duplex {
   emptyBuffer(header) {
     return new Promise((fulfill, reject) => {
       this.emptyBufferDone = fulfill;
-      this.component.emptyBufferAsync(header, function() {
+      this.component.emptyBufferAsync(header, function () {
       });
     });
   }
   fillBuffer(header) {
     return new Promise((fulfill, reject) => {
-      this.component.fillBufferAsync(header, function() {
+      this.component.fillBufferAsync(header, function () {
         fulfill();
       });
     });
@@ -478,7 +478,7 @@ export class Component extends stream.Duplex {
     }
 
     sinkPortPromise
-      .then(function() {
+      .then(function () {
         return sourcePortPromise;
       })
       .then(() => {
@@ -536,6 +536,7 @@ export class Component extends stream.Duplex {
       buffer.onBufferDone = () => {
         this.fillBuffer(outputBuffer.header);
       };
+      buffer.usedLength = outputBuffer.header.nFilledLen;
     }
     this.push(buffer);
   }


### PR DESCRIPTION
This is a simple example to use the ImageEncode component to convert live video into a stream of jpeg files. The purpose is to use this data flow to create a set of jpeg images to push to a browser using websockets.

However, the size that I get in the socket is all the time the same, regardless of the actual jpeg size, and I do not know how to find out the actual buffer length.

